### PR TITLE
add public/system to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 /log/*
 !/log/.keep
 /tmp
+/public/system
 
 # Ignore application configuration
 /config/application.yml


### PR DESCRIPTION
tests seemed to be creating lots of image files in public/system. it appears to be a folder that is often gitignored.